### PR TITLE
fix: Ignore `%#codegen` compilation directive

### DIFF
--- a/src/mkdocstrings_handlers/matlab/treesitter.py
+++ b/src/mkdocstrings_handlers/matlab/treesitter.py
@@ -621,6 +621,9 @@ class FileParser(object):
             except StopIteration:
                 break
 
+            if line == '%#codegen':
+                continue
+
             if "--8<--" in line:
                 continue
 

--- a/src/mkdocstrings_handlers/matlab/treesitter.py
+++ b/src/mkdocstrings_handlers/matlab/treesitter.py
@@ -621,7 +621,16 @@ class FileParser(object):
             except StopIteration:
                 break
 
-            if line == '%#codegen':
+            # Exclude all pragma's
+            if line in [
+                '%#codegen',
+                '%#eml',
+                '%#external',
+                '%#exclude',
+                '%#function',
+                '%#ok',
+                '%#mex',
+            ]:
                 continue
 
             if "--8<--" in line:


### PR DESCRIPTION
The `%#codegen` [compilation directive](https://nl.mathworks.com/help/coder/ug/adding-the-compilation-directive-codegen.html) is interpreted as `# codegen`, which is an H1 header in Markdown.

If I change `docs/snippets/myClass.m` to

```matlab
classdef myClass < myParent  %#codegen
    % Docstring of myClass.
end
```

Then this is what it looks like (notice "codegen" in bold):

![image](https://github.com/user-attachments/assets/d190bb4d-71aa-44df-9497-eaffe13bf51c)

The text "codegen" also shows up in the table of contents, if that is enabled.

This change ignores `%#codegen` outright, similar to how `--8<--` is ignored.