### PR TITLE
feature: Show details (file, lineno...) on parse error

### DIFF
--- a/src/mkdocstrings_handlers/matlab/handler.py
+++ b/src/mkdocstrings_handlers/matlab/handler.py
@@ -358,7 +358,15 @@ class MatlabHandler(BaseHandler):
             raise CollectionError("Empty identifier")
 
         final_config = ChainMap(config, self.default_config)  # type: ignore[arg-type]
-        model = self.paths.resolve(identifier, config=final_config)
+        try:
+            model = self.paths.resolve(identifier, config=final_config)
+        except SyntaxError as ex:
+            msg = str(ex)
+            if ex.text:
+                msg += ':\n' + ex.text
+            raise CollectionError(msg) from ex
+        except Exception as ex:
+            raise CollectionError(str(ex)) from ex
         if model is None:
             raise CollectionError(f"Identifier '{identifier}' not found")
         return model


### PR DESCRIPTION
When there is a parse error, it is useful to know which file failed to parse, and where. This PR changes `parse()` to generate a `SyntaxError` when an exception is raised during parsing.

Using the error from #62 as an example:

Before:

```
ERROR   -  Error reading page 'usage/configuration/docstrings.md': list index out of range
Traceback (most recent call last):
  File "$HOME/.local/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/usr/lib/python3/dist-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3/dist-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3/dist-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "$HOME/.local/lib/python3.10/site-packages/mkdocs/__main__.py", line 288, in build_command
    build.build(cfg, dirty=not clean)
  File "$HOME/.local/lib/python3.10/site-packages/mkdocs/commands/build.py", line 310, in build
    _populate_page(file.page, config, files, dirty)
  File "$HOME/.local/lib/python3.10/site-packages/mkdocs/commands/build.py", line 167, in _populate_page
    page.render(config, files)
  File "$HOME/.local/lib/python3.10/site-packages/mkdocs/structure/pages.py", line 285, in render
    self.content = md.convert(self.markdown)
  File "$HOME/.local/lib/python3.10/site-packages/markdown/core.py", line 357, in convert
    root = self.parser.parseDocument(self.lines).getroot()
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 117, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 136, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 158, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "$HOME/.local/lib/python3.10/site-packages/pymdownx/details.py", line 169, in run
    self.parser.parseChunk(div, block)
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 136, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 158, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "$HOME/.local/lib/python3.10/site-packages/pymdownx/tabbed.py", line 296, in run
    self.parser.parseChunk(div, block)
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 136, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "$HOME/.local/lib/python3.10/site-packages/markdown/blockparser.py", line 158, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "$HOME/.local/lib/python3.10/site-packages/mkdocstrings/extension.py", line 130, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
  File "$HOME/.local/lib/python3.10/site-packages/mkdocstrings/extension.py", line 218, in _process_block
    data: CollectorItem = handler.collect(identifier, options)
  File "$HOME/github.com/watermarkhu/mkdocstrings-matlab/src/mkdocstrings_handlers/matlab/handler.py", line 361, in collect
    model = self.paths.resolve(identifier, config=final_config)
  File "$HOME/github.com/watermarkhu/mkdocstrings-matlab/src/mkdocstrings_handlers/matlab/collect.py", line 194, in resolve
    model = self._models[self._mapping[identifier][0]].model()
  File "$HOME/github.com/watermarkhu/mkdocstrings-matlab/src/mkdocstrings_handlers/matlab/collect.py", line 704, in model
    self._model = self._collect_path(self._path)
  File "$HOME/github.com/watermarkhu/mkdocstrings-matlab/src/mkdocstrings_handlers/matlab/collect.py", line 721, in _collect_path
    model = file.parse(path_collection=self._path_collection, **kwargs)
  File "$HOME/github.com/watermarkhu/mkdocstrings-matlab/src/mkdocstrings_handlers/matlab/treesitter.py", line 237, in parse
    model = self._parse_function(captures["function"][0], **kwargs)
  File "$HOME/github.com/watermarkhu/mkdocstrings-matlab/src/mkdocstrings_handlers/matlab/treesitter.py", line 432, in _parse_function
    captures: dict = FUNCTION_QUERY.matches(node)[0][1]
IndexError: list index out of range
```

After:

```
ERROR   -  mkdocstrings: Error parsing Matlab file (typed_function.m, line 1):
           function output = ...
                 typed_function(input, options)
               % Example function with typed inputs and outputs
               arguments (Input)
                   input (1,1) string % The input variable
                   options.keyword (1,1) double = 0 % An optional keyword argument
               end
               arguments (Output)
                   output (1,:) char % The output variable
               end
               output = char(input);
           end
ERROR   -  Error reading page 'usage/configuration/docstrings.md':
ERROR   -  Could not collect 'mynamespace.typed_function'
```
