### PR TITLE
docs: document config with zensical.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">mkdocstrings-matlab</h1>
 
-<p align="center">A MATLAB handler for <a href="https://github.com/mkdocstrings/mkdocstrings"><i>mkdocstrings</i></a>.</p>
+<p align="center">A MATLAB handler for <a href="https://github.com/mkdocstrings/mkdocstrings"><i>mkdocstrings</i></a>,</br>compatible with <a href="https://squidfunk.github.io/mkdocs-material">Material for MkDocs</a> and <a href="https://zensical.org/about/">Zensical</a>.</p>
 
 <p align="center"><img width=300px src="logo.png"></p>
 
@@ -30,6 +30,8 @@ To get started, checkout the [📝 documentation](https://watermarkhu.github.io/
 <!-- --8<-- [start:footer] -->
 
 ## Features
+
+- Compatible with both [Material for Mkdocs](https://squidfunk.github.io/mkdocs-material) and [Zensical](https://zensical.org/about/).
 
 - 🤖 **Data collection from source code**: collection of the object-tree and the docstrings is done thanks to
   [Tree-sitter](https://tree-sitter.github.io/tree-sitter/).

--- a/docs/usage/configuration/docstrings.md
+++ b/docs/usage/configuration/docstrings.md
@@ -18,14 +18,23 @@ Possible values:
 - `"sphinx"`: see [Sphinx style](../docstrings/sphinx.md).
 - `None` (`null` or `~` in YAML): no style at all, parse as regular text.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          docstring_style: google
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              docstring_style: google
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    docstring_style = "google"
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -100,15 +109,24 @@ The Sphinx style does not offer any option.
 
 Most of the options in the linked pages will not have an effect to mkdocstrings-matlab, since here the objects are mocked as Python objects are docstrings are injected into the mocked objects. 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          docstring_options:
-            warn_unknown_params: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              docstring_options:
+                warn_unknown_params: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    docstring_options = { warn_unknown_params = false }
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -132,14 +150,23 @@ Sections are parsed as structured data and can therefore be rendered in differen
 - `"list"`: a simple list, akin to what you get with the [ReadTheDocs Sphinx theme]{ .external }
 - `"spacy"`: a poor implementation of the amazing tables in [Spacy's documentation]{ .external }
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          docstring_section_style: table
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              docstring_section_style: table
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    docstring_section_style = "table"
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -225,14 +252,23 @@ end
 The mkdocstrings-matlab plugin is able to parse the argument blocks and extract the type and default information, and any comment after each Argument Definition will be parsed as the argument docstring. If if `parse_arguments` is enabled, sections will be rendered for the parameters, name-value pairs and the return arguments of functions and methods. These sections can be individually toggled with [`show_docstring_input_arguments`][], [`show_docstring_name_value_arguments`][] and [`show_docstring_output_arguments`][].
 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          parse_arguments: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              parse_arguments: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    parse_arguments = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mynamespace.typed_function
@@ -281,14 +317,23 @@ Whether to merge the constructor method into the class' signature and docstring.
 
 By default, only the class name is rendered in headings. When merging, the constructor method parameters are added after the class name, like a signature, and the constructor method docstring is appended to the class' docstring. 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          merge_constructor_into_class: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              merge_constructor_into_class: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    merge_constructor_into_class = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -345,14 +390,23 @@ Without an explicit list of [`members`][], members are selected based on [`filte
 
 With this option you can tell the Python handler to skip the docstring check.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_if_no_docstring: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_if_no_docstring: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_if_no_docstring = false
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: +undocumented
@@ -395,14 +449,23 @@ plugins:
 
 Whether to render the "Properties" sections of docstrings.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_properties: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_properties: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_properties = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -449,14 +512,23 @@ plugins:
 
 Whether to render the "Functions" or "Methods" sections of docstrings.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      python:
-        options:
-          show_docstring_functions: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          python:
+            options:
+              show_docstring_functions: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.python.options]
+    show_docstring_functions = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: path.to.module
@@ -527,14 +599,23 @@ plugins:
 
 Whether to render the "Classes" sections of docstrings.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_classes: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_classes: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_classes = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: +matlab_namespace
@@ -582,14 +663,23 @@ plugins:
 
 Whether to render the "Namespaces" sections of docstrings.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_namespaces: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_namespaces: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_namespaces = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: +matlab_namespace
@@ -636,14 +726,23 @@ plugins:
 
 Whether to render the textual blocks (including admonitions) of docstrings.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_description: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_description: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_description = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -690,14 +789,23 @@ plugins:
 
 Whether to render the "Examples" sections of docstrings.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_examples: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_examples: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_examples = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -744,14 +852,23 @@ plugins:
 
 Whether to render the "Parameters" sections of docstrings. The accepted title headings are `inputs` or `input arguments` (case-insensitive). 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_input_arguments: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_input_arguments: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_input_arguments = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -802,14 +919,23 @@ plugins:
 
 Whether to render the "Name-value pairs" sections of docstrings. The accepted title headings are `name-value pairs` or `name-value arguments` (case-insensitive). 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_name_value_arguments: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_name_value_arguments: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_name_value_arguments = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -860,14 +986,23 @@ plugins:
 
 Whether to render the "Returns" sections of docstrings. The accepted title headings are `outputs` or `output arguments` (case-insensitive). 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_docstring_output_arguments: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_docstring_output_arguments: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_docstring_output_arguments = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable

--- a/docs/usage/configuration/general.md
+++ b/docs/usage/configuration/general.md
@@ -11,14 +11,23 @@ toc_depth: 2
 
 Show the base classes of a class.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_bases: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_bases: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_bases = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -75,14 +84,23 @@ extra_javascript:
 - https://unpkg.com/mermaid@10.9.0/dist/mermaid.min.js
 ```
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_inheritance_diagram: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_inheritance_diagram: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_inheritance_diagram = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -116,14 +134,23 @@ plugins:
 
 Show the source code of this object.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_source: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_source: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_source = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable

--- a/docs/usage/configuration/headings.md
+++ b/docs/usage/configuration/headings.md
@@ -17,14 +17,23 @@ The initial heading level will be used for the first layer. If you set it to 3, 
 
 If the [heading for the root object][show_root_heading] is not shown, then the initial heading level is used for its members.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          heading_level: 2
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              heading_level: 2
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    heading_level = 2
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -76,14 +85,23 @@ The identifier used in the permalink and inventory is of the following form: `pa
 - Varargin: [`varargin`][package.module.function(varargin)]
 ```
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          argument_headings: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              argument_headings: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    argument_headings = false
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -172,14 +190,23 @@ It is pretty common to inject documentation for one module per page. Since each 
 
 Sparing that extra level can be helpful when your objects tree is deeply nested (e.g. method in a class in a class in a module). If your objects tree is not deeply nested, and you are injecting documentation for many different objects on a single page, it might be preferable to render the heading of each object.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_root_heading: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_root_heading: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_root_heading = false
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mynamespace.ClassA
@@ -227,14 +254,23 @@ If you inject documentation for an object in the middle of a page, after long pa
 
 In other cases, you might want to disable the entry to avoid polluting the ToC. It is not possible to show the root heading *and* hide the ToC entry.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_root_toc_entry: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_root_toc_entry: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_root_toc_entry = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ## Some heading
@@ -288,14 +324,23 @@ The namespace path of a MATLAB object is the dot-separated list of names under w
 
 With this option you can choose to show the full path of the object you inject documentation for, or just its name. This option impacts only the object you specify, not its members. For members, see the two other options [`show_root_members_full_path`][] and [`show_object_full_path`][].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_root_full_path: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_root_full_path: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_root_full_path = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mynamespace.classA
@@ -342,14 +387,23 @@ This option does the same thing as [`show_root_full_path`][], but for direct mem
 
 To show the full path for every member recursively, see [`show_object_full_path`][].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_root_members_full_path: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_root_members_full_path: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_root_members_full_path = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mynamespace.classA
@@ -401,14 +455,23 @@ False                         | True                    | Full
 True                          | False                   | Full
 True                          | True                    | Full
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_object_full_path: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_object_full_path: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_object_full_path = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: +mynamespace
@@ -459,15 +522,25 @@ allowing you to link to them using their permalinks.
 
     When injecting documentation for deeply nested objects, you'll quickly run out of heading levels, and the objects at the bottom of the tree risk all getting documented using H6 headings, which might decrease the readability of your API docs. 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          group_by_category: true
-          show_category_heading: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              group_by_category: true
+              show_category_heading: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    group_by_category = true
+    show_category_heading = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -529,14 +602,23 @@ This option will prefix headings with
 <code class="doc-symbol doc-symbol-folder"></code> types.
 See also [`show_symbol_type_toc`][show_symbol_type_toc].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_symbol_type_heading: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_symbol_type_heading: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_symbol_type_heading = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -601,14 +683,23 @@ This option will prefix items in the ToC with
 <code class="doc-symbol doc-symbol-folder"></code> types.
 See also [`show_symbol_type_heading`][show_symbol_type_heading].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_symbol_type_toc: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_symbol_type_toc: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_symbol_type_toc = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable

--- a/docs/usage/configuration/members.md
+++ b/docs/usage/configuration/members.md
@@ -20,15 +20,24 @@ Passing a falsy value (`no`, `false` in YAML) or an empty list (`[]`) will tell 
 
 Any given value, except for an explicit `None` (`null` in YAML) will tell the handler to ignore [`filters`][] for the object's members. Filters will still be applied to the next layers of members (grand-children).
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          members:
-          - hello  # (1)
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              members:
+              - hello  # (1)
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    members = ["hello"]
+    ```
 
 1. :warning: Most of the time it won't make sense to use this option at the global level.
 
@@ -95,14 +104,23 @@ MATLAB's [classes](https://mathworks.com/help/matlab/matlab_oop/class-attributes
 
 This takes precedence over [`members`][] and [`filters`][], and also applies for [`inherited_members`][]. This means that for any hidden member to be shown, `hidden_members` must be enabled, and further selection is possible via [`members`][] and [`filters`][]. Hidden members will be labeled `Hidden`, this can be disabled in [`show_attributes`][]. 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          hidden_members: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              hidden_members: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    hidden_members = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mymembers.ThisClass
@@ -182,14 +200,23 @@ ga -- yes --> public
 
 This takes precedence over [`members`][] and [`filters`][], and also applies for [`inherited_members`][]. This means that for any private member to be shown, `private_members` must be enabled, and further selection is possible via [`members`][] and [`filters`][]. Private members will be labeled with it access attribute setting, this can be disabled in [`show_attributes`][]. 
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          private_members: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              private_members: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    private_members = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mymembers.ThisClass
@@ -321,14 +348,23 @@ members: true
 
 The general rule is that declared or inherited members specified in lists are never filtered out.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          inherited_members: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              inherited_members: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    inherited_members = false
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mymembers.ThisClass
@@ -379,14 +415,23 @@ The order will be ignored for members that are explicitely sorted using the [`me
 **Note that members will still be grouped by category,
 according to the [`group_by_category`][] option.**
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          members_order: alphabetical
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              members_order: alphabetical
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    members_order = "alphabetical"
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mymembers.ThisClass
@@ -446,15 +491,24 @@ If there are no negative filters, the handler considers that everything is **uns
 
 An empty list of filters tells the MATLAB handler to render every object. The [`members`][] option takes precedence over filters (filters will still be applied recursively to lower members in the hierarchy).
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          filters:
-          - "!^delete$|^disp$"
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              filters:
+              - "!^delete$|^disp$"
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    filters = ["!^delete$|^disp$"]
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -512,14 +566,23 @@ Group the object members by categories: properties, classes, functions, and name
 
 Members within a same category will be ordered according to the [`members_order`][] option. You can use the [`show_category_heading`][] option to also render a heading for each category.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          group_by_category: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              group_by_category: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    group_by_category = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: +mymembers
@@ -579,14 +642,23 @@ When rendering a namespace, show its subnamespaces recursively.
 
 This is false by default, because most of the time we render only one namespace per page, and when rendering a full package (a tree of namespaces and their members) on a single page, we quickly run out of [heading levels][heading_level].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_subnamespaces: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_subnamespaces: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_subnamespaces = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: +matlab_namespace
@@ -636,14 +708,23 @@ When rendering a folder, show its subfolders recursively.
 
 This is false by default, because most of the time we render only one directory per page, and when rendering a full directory on a single page, we quickly run out of [heading levels][heading_level].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_subfolders: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_subfolders: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_subfolders = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: ./path-from-working-directory
@@ -737,14 +818,23 @@ Summaries will be rendered as the corresponding docstring sections. For example,
 
 Hidden and private members will not be rendered in the summary, no matter the setting in [`hidden_members`][] and [`private_members`][].
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          summary: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              summary: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    summary = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mymembers.ThisClass
@@ -801,14 +891,23 @@ plugins:
 
 Whether to show [property](https://mathworks.com/help/matlab/matlab_oop/property-attributes.html), [method](https://mathworks.com/help/matlab/matlab_oop/method-attributes.html) or [class](https://mathworks.com/help/matlab/matlab_oop/class-attributes.html) attributes of the members.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_attributes: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_attributes: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_attributes = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: mymembers.ThisClass

--- a/docs/usage/configuration/signatures.md
+++ b/docs/usage/configuration/signatures.md
@@ -13,14 +13,23 @@ Show methods and functions signatures.
 
 Without it, just the function/method name is rendered.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_signature: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_signature: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_signature = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: matlab_callable
@@ -69,14 +78,23 @@ Show the type annotations in methods and functions signatures.
 
 Since the heading can become quite long when annotations are rendered, it is usually best to [separate the signature][separate_signature] from the heading.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          show_signature_types: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              show_signature_types: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    show_signature_types = true
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: path.to.module
@@ -128,14 +146,23 @@ plugins:
 
 Whether to put the whole signature in a code block below the heading.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      python:
-        options:
-          separate_signature: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              separate_signature: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    separate_signature = false
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: path.to.module
@@ -185,16 +212,27 @@ Whether to render cross-references for type annotations in signatures.
 
 When signatures are separated from headings with the [`separate_signature`][] option and type annotations are shown with the [`show_signature_types`][] option, this option will render a cross-reference (link) for each type annotation in the signature.
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          separate_signature: true
-          show_signature_types: true
-          signature_crossrefs: false
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              separate_signature: true
+              show_signature_types: true
+              signature_crossrefs: false
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    separate_signature = true
+    show_signature_types = true
+    signature_crossrefs = false
+    ```
 
 ```md title="or in docs/some_page.md (local configuration)"
 ::: path.to.module

--- a/docs/usage/global.md
+++ b/docs/usage/global.md
@@ -6,13 +6,22 @@ This option is used to set the [MATLAB search path](https://mathworks.com/help/m
 
 Non-absolute paths are computed as relative to MkDocs configuration file. Example:
 
-```yaml title="mkdocs.yml"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        paths: [src]  # search files in the src folder
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            paths: [src]  # search files in the src folder
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab]
+    paths = ["src"]  # search files in the src folder
+    ```
 
 
 ## `paths_recursive`
@@ -21,14 +30,25 @@ This option allows you to specify whether the handler should recursively search 
 
 Example:
 
-```yaml title="mkdocs.yml"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        paths: [src]  # search files in the src folder
-        paths_recursive: true  # search recursively in subfolders
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            paths: [src]  # search files in the src folder
+            paths_recursive: true  # search recursively in subfolders
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab]
+    paths = ["src"]  # search files in the src folder
+    paths_recursive = true  # search recursively in subfolders
+    ```
+
 
 ## `tree_sitter_logging_level`
 
@@ -46,13 +66,22 @@ Possible values (from most to least verbose):
 
 Example:
 
-```yaml title="mkdocs.yml"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        tree_sitter_logging_level: DEBUG  # show debug messages during parsing
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            tree_sitter_logging_level: DEBUG  # show debug messages during parsing
+    ```
+
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab]
+    tree_sitter_logging_level = "DEBUG"  # show debug messages during parsing
+    ```
 
 
 ## `docstring_before_properties`
@@ -87,16 +116,25 @@ classdef MyClass
 end
 ```
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          docstring_before_properties: true
-```
+=== "mkdocs.yml"
 
-```md title="or in docs/some_page.md (local configuration)"
+    ```yaml title="global configuration"
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              docstring_before_properties: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml title="global configuration"
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    docstring_before_properties = true
+    ```
+
+```md title="local configuration"
 ::: matlab_class
     options:
       docstring_before_properties: true
@@ -136,16 +174,25 @@ function result = myFunction(arg1, arg2)
 end
 ```
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          docstring_before_arguments: true
-```
+=== "mkdocs.yml"
 
-```md title="or in docs/some_page.md (local configuration)"
+    ```yaml title="global configuration"
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              docstring_before_arguments: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml title="global configuration"
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    docstring_before_arguments = true
+    ```
+
+```md title="local configuration"
 ::: matlab_function
     options:
       docstring_before_arguments: true
@@ -183,16 +230,25 @@ classdef MyEnum
 end
 ```
 
-```yaml title="in mkdocs.yml (global configuration)"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          docstring_before_enumerations: true
-```
+=== "mkdocs.yml"
 
-```md title="or in docs/some_page.md (local configuration)"
+    ```yaml title="global configuration"
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              docstring_before_enumerations: true
+    ```
+
+=== "zensical.toml"
+
+    ```toml title="global configuration"
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    docstring_before_enumerations = true
+    ```
+
+```md title="local configuration"
 ::: matlab_enumeration
     options:
       docstring_before_enumerations: true

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -2,34 +2,48 @@
 
 ## Installation
 
-You can install this handler by specifying it as a dependency:
+You can install this handler by installing is as a dependency
 
-```toml title="pyproject.toml"
-# PEP 621 dependencies declaration
-# adapt to your dependencies manager
-[project]
-dependencies = [
-    "mkdocstrings-matlab>=0.X.Y",
-]
+```shell
+uv add mkdocstrings-matlab --group docs
+```
+or 
+
+```shell
+pip install mkdocstrings-matlab
 ```
 
 ## Configuration
 
+The current package serves as an language extension to [mkdocstrings](https://mkdocstrings.github.io/), an auto-documentation framework that is compatible with both MkDocs and [Zensical](https://zensical.org/about/) (a continueation of [Material for MkDocs](https://squidfunk.github.io/mkdocs-material)). MkDocs uses `mkdocs.yml` for the project configuration. Zensical introduces a `zensical.toml`, but is compatible with `mkdocs.yml` as well.
+
 For *mkdocstrings* the default will be the Python handler. You can change the default handler,
 or explicitely set the MATLAB handler as default by defining the `default_handler`
-configuration option of `mkdocstrings` in `mkdocs.yml`:
+configuration option of `mkdocstrings` in `mkdocs.yml` or `zensical.toml`:
 
-```yaml title="mkdocs.yml"
-plugins:
-- mkdocstrings:
-    default_handler: matlab
-    matlab:
-        ...  # the MATLAB handler configuration
-```
+=== "mkdocs.yml"
+
+    ```yaml title="mkdocs.yml"
+    plugins:
+    - mkdocstrings:
+        default_handler: matlab
+        matlab:
+            ...  # the MATLAB handler configuration
+    ```
+    
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings]
+    default_handler = "matlab"
+    
+    [project.plugins.mkdocstrings.matlab]
+    # The MATLAB handler configuration
+    ```
 
 ## Injecting documentation
 
-With the MATLAB handler installed and configured as default handler, you can inject documentation for a module, class, function, or any other MATLAB object with *mkdocstrings*' [autodoc syntax], in your Markdown pages:
+With the MATLAB handler installed and configured as default handler, you can inject documentation for a module, class, function, or any other MATLAB object with *mkdocstrings*' `[autodoc syntax]`, in your Markdown pages:
 
 ```md
 ::: path.to.object
@@ -45,13 +59,13 @@ If another handler was defined as default handler, you can explicitely ask for t
 
 Entire [namespaces](https://mathworks.com/help/matlab/matlab_oop/namespaces.html) can be fully documented by prefixing the `+` character to the namespace that is to be documented. E.g. the following namespace 
 
-```tree
+```text
 +mynamespace
-    Contents.m
-    readme.md
-    myclass.m
-    +subnamespace
-        mfunction.m
+├── Contents.m
+├── readme.md
+├── myclass.m
+└── +subnamespace
+    └── mfunction.m
 ```
 
 is documented with:
@@ -70,20 +84,21 @@ Documenting a nested namespace requires only a single prefixed `+` at the start 
 
 ### Folders
 
-Similarly to namepaces, all contents of a folder can be fully documented by specifying the relative path of a folder with respect to the `mkdocs.yml` config file. E.g. the following repository
+Similarly to namepaces, all contents of a folder can be fully documented by specifying the relative path of a folder with respect to the config file. E.g. the following repository
 
-```tree
+```text
 src
-    module
-        myfunction.m
-        myClass.m
-        submodule
-            myfunction.m
-        +mynamespace
-            namespacefunction.m
+└── module
+    ├── myfunction.m
+    ├── myClass.m
+    ├── submodule
+    │   └── myfunction.m
+    └── +mynamespace
+        └── namespacefunction.m
 docs
-    index.md
-mkdocs.yml
+└── index.md
+mkdocs.yml # or
+zensical.toml
 ```
 
 is documented with:
@@ -102,11 +117,11 @@ While this kind of behavior is strictly recommended against, mkdocstrings-matlab
 
 !!! tip
 
-    A folder identifier must strictly contain the `/` character. For a folder `foo` that is in the same directory with `mkdocs.yml`, use `::: ./foo`. 
+    A folder identifier must strictly contain the `/` character. For a folder `foo` that is in the same directory containing `mkdocs.yml` or `zensical.toml`, use `::: ./foo`. 
 
 !!! tip
 
-    If the `mkdocs.yml` lives inside of a subdirectly that does not contain source code, use relative paths e.g. `../src/module`. 
+    If `mkdocs.yml` or `zensical.toml` lives inside of a subdirectly that does not contain source code, use relative paths e.g. `../src/module`. 
 
 !!! tip
 
@@ -116,19 +131,27 @@ While this kind of behavior is strictly recommended against, mkdocstrings-matlab
 
 Some options are **global only**, and go directly under the handler's name. See all global only options [here](./global.md).
 
-### Global/local options
+### Global and local options
 
 The other options can be used both globally *and* locally, under the `options` key.
 For example, globally:
 
-```yaml title="mkdocs.yml"
-plugins:
-- mkdocstrings:
-    handlers:
-      matlab:
-        options:
-          do_something: true
-```
+=== "mkdocs.yml"
+
+    ```yaml
+    plugins:
+    - mkdocstrings:
+        handlers:
+          matlab:
+            options:
+              do_something: true
+    ```
+=== "zensical.toml"
+
+    ```toml
+    [project.plugins.mkdocstrings.handlers.matlab.options]
+    do_something = true
+    ```
 
 ...and locally, overriding the global configuration:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ validation:
   unrecognized_links: warn
 
 watch:
+  - README.md
   - mkdocs.yml
   - docs
   - src
@@ -25,7 +26,7 @@ nav:
   - Usage:
       - usage/index.md
       - Global options: usage/global.md
-      - Global/local options:
+      - Global and local options:
           - General: usage/configuration/general.md
           - Headings: usage/configuration/headings.md
           - Members: usage/configuration/members.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to highlight compatibility with Material for MkDocs and Zensical.
  * Expanded configuration documentation with dual-format examples supporting both `mkdocs.yml` (YAML) and `zensical.toml` (TOML) across all configuration option sections.
  * Improved installation and usage guidance with multi-tool support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->